### PR TITLE
Add header and footer components to layout

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,7 @@
+---
+const currentYear = new Date().getFullYear();
+---
+
+<footer>
+	<p>&copy; {currentYear}</p>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,5 @@
+<header>
+	<nav>
+		<a href="/">Home</a>
+	</nav>
+</header>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,7 @@
 ---
 import "../styles/global.css";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
 ---
 
 <!doctype html>
@@ -12,7 +14,9 @@ import "../styles/global.css";
 		<title>Astro Basics</title>
 	</head>
 	<body>
+		<Header />
 		<slot />
+		<Footer />
 	</body>
 </html>
 

--- a/tests/layout.spec.ts
+++ b/tests/layout.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('header and footer are visible on homepage', async ({ page }) => {
+  await page.goto("http://localhost:4321/");
+
+  const header = page.locator('header');
+  const footer = page.locator('footer');
+  
+  await expect(header).toBeVisible();
+  await expect(footer).toBeVisible();
+  
+  const homeLink = page.locator('header nav a[href="/"]');
+  await expect(homeLink).toBeVisible();
+  await expect(homeLink).toHaveText('Home');
+  
+  const currentYear = new Date().getFullYear();
+  const copyrightText = page.locator('footer p');
+  await expect(copyrightText).toHaveText(`© ${currentYear}`);
+});


### PR DESCRIPTION
Adds Header and Footer components with semantic HTML structure to the main layout.

## Acceptance Criteria
- [x] Header component created with homepage link
- [x] Footer component created with dynamic copyright year
- [x] Both components use proper semantic HTML
- [x] Components are integrated into Layout.astro
- [x] No CSS styling applied yet
- [x] Homepage link works correctly
- [x] Copyright year displays current year automatically
- [x] Code follows Astro component conventions
- [x] Layout test passes

Fixes #3