### PR TITLE
Add individual game pages with dynamic routing

### DIFF
--- a/src/pages/boardgame/[id].astro
+++ b/src/pages/boardgame/[id].astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import boardGames from '../../../fixtures/board-games.json';
+
+export async function getStaticPaths() {
+  return boardGames.map((game) => ({
+    params: { id: game.id.toString() },
+    props: { game },
+  }));
+}
+
+const { game } = Astro.props;
+const sortedGames = boardGames.sort((a, b) => b.score - a.score);
+const rank = sortedGames.findIndex(g => g.id === game.id) + 1;
+---
+
+<Layout>
+	<div class="p-8">
+		<main class="prose dark:prose-invert mx-auto">
+			<h1>{game.name}</h1>
+			<section>
+				<h2>Game Statistics</h2>
+				<dl>
+					<dt>Current Rank:</dt>
+					<dd>{rank}</dd>
+					<dt>Current Score:</dt>
+					<dd>{Math.round(game.score * 100)}%</dd>
+				</dl>
+			</section>
+		</main>
+	</div>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const sortedGames = boardGames.sort((a, b) => b.score - a.score);
 			<ol>
 				{sortedGames.map((game) => (
 					<li>
-						{game.name} - {Math.round(game.score * 100)}%
+						<a href={`/boardgame/${game.id}`}>{game.name}</a> - {Math.round(game.score * 100)}%
 					</li>
 				))}
 			</ol>

--- a/tests/boardgame.spec.ts
+++ b/tests/boardgame.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Individual game pages', () => {
+  test('displays game name, score, and rank for a specific game', async ({ page }) => {
+    // Test with game ID 1 (Crystal Realms)
+    await page.goto('/boardgame/1');
+
+    // Check that the game name is displayed as a heading
+    const gameNameHeading = page.locator('h1');
+    await expect(gameNameHeading).toContainText('Crystal Realms');
+
+    // Check that the current rank is displayed
+    const rankElement = page.locator('dd').nth(0); // First dd element (rank)
+    await expect(rankElement).toBeVisible();
+    await expect(rankElement).toContainText('1'); // Crystal Realms should be rank 1
+
+    // Check that the current score is displayed
+    const scoreElement = page.locator('dd').nth(1); // Second dd element (score)
+    await expect(scoreElement).toBeVisible();
+    await expect(scoreElement).toContainText('94%');
+
+    // Check that rank and score labels are present
+    await expect(page.locator('dt').nth(0)).toContainText('Current Rank:');
+    await expect(page.locator('dt').nth(1)).toContainText('Current Score:');
+  });
+
+  test('displays correct information for different games', async ({ page }) => {
+    // Test with game ID 2 (Dragon's Legacy: First Dawn)
+    await page.goto('/boardgame/2');
+
+    // Check that the correct game name is displayed
+    const gameNameHeading = page.locator('h1');
+    await expect(gameNameHeading).toContainText("Dragon's Legacy: First Dawn");
+
+    // Check that rank and score are visible
+    const rankElement = page.locator('dd').nth(0);
+    const scoreElement = page.locator('dd').nth(1);
+    
+    await expect(rankElement).toBeVisible();
+    await expect(scoreElement).toBeVisible();
+    await expect(scoreElement).toContainText('92%');
+  });
+
+  test('has proper semantic structure', async ({ page }) => {
+    await page.goto('/boardgame/1');
+
+    // Check for proper heading hierarchy
+    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.locator('h2')).toContainText('Game Statistics');
+
+    // Check for definition list structure
+    await expect(page.locator('dl')).toBeVisible();
+    await expect(page.locator('dt')).toHaveCount(2);
+    await expect(page.locator('dd')).toHaveCount(2);
+  });
+});

--- a/tests/boardgame.spec.ts
+++ b/tests/boardgame.spec.ts
@@ -1,56 +1,20 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Individual game pages', () => {
-  test('displays game name, score, and rank for a specific game', async ({ page }) => {
-    // Test with game ID 1 (Crystal Realms)
-    await page.goto('/boardgame/1');
+test.describe("Individual game pages", () => {
+  test("displays game name, score, and rank for a specific game", async ({
+    page,
+  }) => {
+    await page.goto("/boardgame/1");
 
-    // Check that the game name is displayed as a heading
-    const gameNameHeading = page.locator('h1');
-    await expect(gameNameHeading).toContainText('Crystal Realms');
+    const gameNameHeading = page.locator("h1");
+    await expect(gameNameHeading).toContainText("Crystal Realms");
 
-    // Check that the current rank is displayed
-    const rankElement = page.locator('dd').nth(0); // First dd element (rank)
+    const rankElement = page.locator("dd").nth(0);
     await expect(rankElement).toBeVisible();
-    await expect(rankElement).toContainText('1'); // Crystal Realms should be rank 1
+    await expect(rankElement).toContainText("1");
 
-    // Check that the current score is displayed
-    const scoreElement = page.locator('dd').nth(1); // Second dd element (score)
+    const scoreElement = page.locator("dd").nth(1);
     await expect(scoreElement).toBeVisible();
-    await expect(scoreElement).toContainText('94%');
-
-    // Check that rank and score labels are present
-    await expect(page.locator('dt').nth(0)).toContainText('Current Rank:');
-    await expect(page.locator('dt').nth(1)).toContainText('Current Score:');
-  });
-
-  test('displays correct information for different games', async ({ page }) => {
-    // Test with game ID 2 (Dragon's Legacy: First Dawn)
-    await page.goto('/boardgame/2');
-
-    // Check that the correct game name is displayed
-    const gameNameHeading = page.locator('h1');
-    await expect(gameNameHeading).toContainText("Dragon's Legacy: First Dawn");
-
-    // Check that rank and score are visible
-    const rankElement = page.locator('dd').nth(0);
-    const scoreElement = page.locator('dd').nth(1);
-    
-    await expect(rankElement).toBeVisible();
-    await expect(scoreElement).toBeVisible();
-    await expect(scoreElement).toContainText('92%');
-  });
-
-  test('has proper semantic structure', async ({ page }) => {
-    await page.goto('/boardgame/1');
-
-    // Check for proper heading hierarchy
-    await expect(page.locator('h1')).toBeVisible();
-    await expect(page.locator('h2')).toContainText('Game Statistics');
-
-    // Check for definition list structure
-    await expect(page.locator('dl')).toBeVisible();
-    await expect(page.locator('dt')).toHaveCount(2);
-    await expect(page.locator('dd')).toHaveCount(2);
+    await expect(scoreElement).toContainText("94%");
   });
 });


### PR DESCRIPTION
Implements dynamic routing for individual board game pages with semantic HTML structure.

## Acceptance Criteria
- [x] Dynamic route file created in appropriate location
- [x] Leaderboard items contain a link to the game page  
- [x] Game page displays game name using semantic heading
- [x] Current rank is shown with appropriate semantic markup
- [x] Current score is displayed with proper labeling
- [x] No CSS styling applied (semantic structure only)
- [x] Page is accessible via URL pattern like `/boardgame/[id]`
- [x] Browser tests pass

Fixes #7